### PR TITLE
Fix missing config entry error

### DIFF
--- a/settings.d/host_reports.yml.example
+++ b/settings.d/host_reports.yml.example
@@ -14,3 +14,8 @@
 # - when enabled, move files from the place on
 # a regular basis (e.g. via cronjob).
 :keep_reports: false
+
+# Override host name coming from the report
+# Set to nil or false to disable.
+# Set to prefered host name to override.
+:override_hostname: nil


### PR DESCRIPTION
Fixes `Error details for Disabling all modules in the group ['host_reports'] due to a failure in one of them: Parameter 'override_hostname' is expected to have a non-empty value`.