### PR TITLE
Make body be JSON string and fix tests

### DIFF
--- a/lib/smart_proxy_host_reports/ansible_processor.rb
+++ b/lib/smart_proxy_host_reports/ansible_processor.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class AnsibleProcessor < Processor
-  def initialize(data)
-    super(data)
+  def initialize(data, json_body: true)
+    super(data, json_body: json_body)
     measure :parse do
       @data = JSON.parse(data)
     end
@@ -41,7 +41,7 @@ class AnsibleProcessor < Processor
     if debug_payload?
       logger.debug { JSON.pretty_generate(@body) }
     end
-    report = build_report_root(
+    build_report_root(
       format: "ansible",
       version: 1,
       host: @body["host"],

--- a/lib/smart_proxy_host_reports/host_reports.rb
+++ b/lib/smart_proxy_host_reports/host_reports.rb
@@ -5,9 +5,9 @@ module Proxy::HostReports
     end
 
     def load_dependency_injection_wirings(container, _settings)
-      container.singleton_dependency :host_reports_spool, (lambda do
-        SpooledHttpClient.instance.initialize_directory
-      end)
+      container.singleton_dependency :host_reports_spool, -> {
+          SpooledHttpClient.instance.initialize_directory
+        }
     end
   end
 

--- a/lib/smart_proxy_host_reports/host_reports_api.rb
+++ b/lib/smart_proxy_host_reports/host_reports_api.rb
@@ -8,6 +8,7 @@ require "smart_proxy_host_reports/ansible_processor"
 module Proxy::HostReports
   class Api < ::Sinatra::Base
     include ::Proxy::Log
+    include ::Proxy::Util
     helpers ::Proxy::Helpers
 
     before do
@@ -31,7 +32,8 @@ module Proxy::HostReports
       check_content_type(format)
       input = request.body.read
       log_halt(415, "Missing body") if input.empty?
-      processor = Processor.new_processor(format, input)
+      json_body = to_bool(params[:json_body], true)
+      processor = Processor.new_processor(format, input, json_body: json_body)
       processor.spool_report
     rescue => e
       log_halt 415, e, "Error during report processing: #{e.message}"

--- a/lib/smart_proxy_host_reports/processor.rb
+++ b/lib/smart_proxy_host_reports/processor.rb
@@ -7,20 +7,21 @@ require "proxy/log"
 class Processor
   include ::Proxy::Log
 
-  def self.new_processor(format, data)
+  def self.new_processor(format, data, json_body: true)
     case format
     when "puppet"
-      PuppetProcessor.new(data)
+      PuppetProcessor.new(data, json_body: json_body)
     when "ansible"
-      AnsibleProcessor.new(data)
+      AnsibleProcessor.new(data, json_body: json_body)
     else
       NotImplementedError.new
     end
   end
 
-  def initialize(*)
+  def initialize(*, json_body: true)
     @keywords_set = {}
     @errors = []
+    @json_body = json_body
   end
 
   def generated_report_id
@@ -40,12 +41,11 @@ class Processor
         "reported_at" => reported_at,
         "status" => status,
         "proxy" => proxy,
-        "body" => body,
+        "body" => @json_body ? body.to_json : body,
         "keywords" => keywords,
       },
     }
-    # TODO add body string serialization and metric with total time
-    # and for tests there must be an option to turn this off
+    # TODO add metric with total time
   end
 
   def debug_payload?

--- a/lib/smart_proxy_host_reports/puppet_processor.rb
+++ b/lib/smart_proxy_host_reports/puppet_processor.rb
@@ -5,8 +5,8 @@ class PuppetProcessor < Processor
   KEYS_TO_COPY = %w[report_format puppet_version environment metrics].freeze
   MAX_EVAL_TIMES = 29
 
-  def initialize(data)
-    super(data)
+  def initialize(data, json_body: true)
+    super(data, json_body: json_body)
     measure :parse do
       if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
         # Ruby 2.5 or older does not have permitted_classes argument available
@@ -101,7 +101,7 @@ class PuppetProcessor < Processor
     if debug_payload?
       logger.debug { JSON.pretty_generate(@body) }
     end
-    report = build_report_root(
+    build_report_root(
       format: "puppet",
       version: 1,
       host: @body["host"],

--- a/lib/smart_proxy_host_reports/spooled_http_client.rb
+++ b/lib/smart_proxy_host_reports/spooled_http_client.rb
@@ -65,7 +65,7 @@ class SpooledHttpClient
           post = factory.create_post("/api/v2/host_reports", File.read(filename))
           response = http.request(post)
           logger.info "Report #{basename} sent with HTTP response #{response.code}"
-          logger.debug { "Response body: #{response.body}"}
+          logger.debug { "Response body: #{response.body}" }
           if response.code.start_with?("2")
             if Proxy::HostReports::Plugin.settings.keep_reports
               spool_move("todo", "done", basename)
@@ -73,7 +73,7 @@ class SpooledHttpClient
               FileUtils.rm_f spool_path("todo", basename)
             end
           else
-            logger.debug { "Moving failed report to 'fail' spool directory"}
+            logger.debug { "Moving failed report to 'fail' spool directory" }
             spool_move("todo", "done", basename)
           end
           processed += 1

--- a/test/host_reports_integration_test.rb
+++ b/test/host_reports_integration_test.rb
@@ -7,8 +7,13 @@ class HostReportsIntegrationTest < Test::Unit::TestCase
     Proxy::HostReports::Api.new
   end
 
-  def test_without_content_type
+  def test_without_content_type_and_format
     post "/"
+    assert_equal 404, last_response.status
+  end
+
+  def test_without_content_type
+    post "/puppet"
     assert_equal 415, last_response.status
   end
 

--- a/test/puppet_processor_test.rb
+++ b/test/puppet_processor_test.rb
@@ -7,7 +7,7 @@ class PuppetProcessorTest < Test::Unit::TestCase
 
   def test_deb
     input = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-deb.yaml"))
-    processor = Processor.new_processor("puppet", input)
+    processor = Processor.new_processor("puppet", input, json_body: false)
     result = processor.build_report["host_report"]
     assert_equal "puppet", result["format"]
     assert_equal "deb.example.com", result["host"]
@@ -21,7 +21,7 @@ class PuppetProcessorTest < Test::Unit::TestCase
 
   def test_dis
     input = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-dis.yaml"))
-    processor = Processor.new_processor("puppet", input)
+    processor = Processor.new_processor("puppet", input, json_body: false)
     result = processor.build_report["host_report"]
     assert_equal "puppet", result["format"]
     assert_equal "dis.example.com", result["host"]
@@ -33,7 +33,7 @@ class PuppetProcessorTest < Test::Unit::TestCase
 
   def test_jen
     input = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-jen.yaml"))
-    processor = Processor.new_processor("puppet", input)
+    processor = Processor.new_processor("puppet", input, json_body: false)
     result = processor.build_report["host_report"]
     assert_equal "puppet", result["format"]
     assert_equal "jen.example.com", result["host"]
@@ -47,7 +47,7 @@ class PuppetProcessorTest < Test::Unit::TestCase
 
   def test_old
     input = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-old.yaml"))
-    processor = Processor.new_processor("puppet", input)
+    processor = Processor.new_processor("puppet", input, json_body: false)
     result = processor.build_report["host_report"]
     assert_equal "puppet", result["format"]
     assert_equal "old.example.com", result["host"]
@@ -61,7 +61,7 @@ class PuppetProcessorTest < Test::Unit::TestCase
 
   def test_red
     input = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-red.yaml"))
-    processor = Processor.new_processor("puppet", input)
+    processor = Processor.new_processor("puppet", input, json_body: false)
     result = processor.build_report["host_report"]
     assert_equal "puppet", result["format"]
     assert_equal "red.example.com", result["host"]
@@ -75,7 +75,7 @@ class PuppetProcessorTest < Test::Unit::TestCase
 
   def test_web
     input = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-web.yaml"))
-    processor = Processor.new_processor("puppet", input)
+    processor = Processor.new_processor("puppet", input, json_body: false)
     result = processor.build_report["host_report"]
     assert_equal "puppet", result["format"]
     assert_equal "report.example.com", result["host"]
@@ -95,7 +95,7 @@ class PuppetProcessorTest < Test::Unit::TestCase
 
   def test_web_snapshot
     input = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-web.yaml"))
-    processor = Processor.new_processor("puppet", input)
+    processor = Processor.new_processor("puppet", input, json_body: false)
     result = processor.build_report
     # remove volatile fields
     result["host_report"]["body"]["telemetry"] = {}


### PR DESCRIPTION
I've changed the way the body is represented since it fixes the problem with https://github.com/theforeman/foreman_host_reports/blob/ab78021ca47d1b5676fd9c964206df975dc8ba3d/app/controllers/api/v2/host_reports_controller.rb#L50-L53. The problem is that if the body is not a string then it tries to generate one and the generated one cannot be `JSON.parse`d again. Also, in this way Rails won't parse body into parameters and thus we don't need to change the default behaviour by potentially breaking stuff. Since this plugin is aimed to be used only in `foreman_host_reports` plugin context only, I guess we can afford such change.

Also, made rubocop happy and fixed few tests.

P.S. With this change the report is being saved properly and parsed for view. There is also no additional parsing before save on the Foreman plugin side since the body is a string. The main concern I can see is that the body seems to be double `JSON.dump`ed.