### PR TITLE
Fix magic comment

### DIFF
--- a/lib/smart_proxy_reports/ansible_processor.rb
+++ b/lib/smart_proxy_reports/ansible_processor.rb
@@ -1,6 +1,6 @@
-require_relative "friendly_message"
-
 # frozen_string_literal: true
+
+require_relative "friendly_message"
 
 module Proxy::Reports
   class AnsibleProcessor < Processor


### PR DESCRIPTION
Sorry I overlooked this :/

Magic comments must be as the first line in a file, otherwise it doesn't do anything.