### PR TITLE
Implement final mapping for proxy

### DIFF
--- a/lib/smart_proxy_reports/processor.rb
+++ b/lib/smart_proxy_reports/processor.rb
@@ -31,7 +31,7 @@ module Proxy::Reports
       @hostname_from_config ||= Proxy::Reports::Plugin.settings.override_hostname
     end
 
-    def build_report_root(format:, version:, host:, reported_at:, statuses:, proxy:, body:, keywords:)
+    def build_report_root(format:, version:, host:, reported_at:, proxy:, change:, nochange:, failure:, body:, keywords:)
       {
         "host_report" => {
           "format" => format,
@@ -41,7 +41,10 @@ module Proxy::Reports
           "proxy" => proxy,
           "body" => @json_body ? body.to_json : body,
           "keywords" => keywords,
-        }.merge(statuses),
+          "change" => change,
+          "nochange" => nochange,
+          "failure" => failure,
+        },
       }
       # TODO add metric with total time
     end
@@ -67,8 +70,14 @@ module Proxy::Reports
 
     attr_reader :errors
 
-    def log_error(message)
-      @errors << message.to_s
+    def log_error(message, exception = nil)
+      msg = if exception
+          "#{message}: #{exception}"
+        else
+          message
+        end
+      logger.error msg, exception
+      @errors << msg.to_s
     end
 
     def errors?

--- a/test/fixtures/ansible-copy-nochange.json
+++ b/test/fixtures/ansible-copy-nochange.json
@@ -68,9 +68,13 @@
             }
         }
     ],
-    "status": {
-        "applied": 0,
-        "failed": 0,
+    "summary": {
+        "ok": 1,
+        "changed": 0,
+        "failures": 0,
+        "unreachable": 0,
+        "rescued": 0,
+        "ignored": 0,
         "skipped": 0
     }
 }

--- a/test/snapshots/ansible-copy-nochange.json.snapshot.json
+++ b/test/snapshots/ansible-copy-nochange.json.snapshot.json
@@ -76,24 +76,34 @@
           "friendly_message": "Copy hosts to /tmp/hosts"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 1,
+          "failure": 0
+        },
+        "native": {
+          "ok": 1,
+          "changed": 0,
+          "failures": 0,
+          "unreachable": 0,
+          "rescued": 0,
+          "ignored": 0,
+          "skipped": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 1,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-copy-success.json.snapshot.json
+++ b/test/snapshots/ansible-copy-success.json.snapshot.json
@@ -67,24 +67,34 @@
           "friendly_message": "Copy hosts to /tmp/hosts"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 1,
+          "nochange": 0,
+          "failure": 0
+        },
+        "native": {
+          "changed": 1,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
-        "HasChange"
+        "AnsibleChanged"
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 1,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
-      "HasChange"
+      "AnsibleChanged"
     ],
-    "applied": 1,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 1,
+    "nochange": 0,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-install-vim-success-l1.json.snapshot.json
+++ b/test/snapshots/ansible-install-vim-success-l1.json.snapshot.json
@@ -311,24 +311,34 @@
           "friendly_message": "N/A"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 6,
+          "failure": 0
+        },
+        "native": {
+          "changed": 0,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 6,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-install-vim-success-l2.json.snapshot.json
+++ b/test/snapshots/ansible-install-vim-success-l2.json.snapshot.json
@@ -311,24 +311,34 @@
           "friendly_message": "N/A"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 6,
+          "failure": 0
+        },
+        "native": {
+          "changed": 0,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 6,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-package-install-failure.json.snapshot.json
+++ b/test/snapshots/ansible-package-install-failure.json.snapshot.json
@@ -70,26 +70,36 @@
           "friendly_message": "Failed to install some of the specified packages"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 1,
+          "failure": 1
+        },
+        "native": {
+          "changed": 0,
+          "failures": 1,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
-        "HasFailure",
-        "AnsibleTaskFailed:ansible.builtin.package"
+        "AnsibleFailure",
+        "AnsibleFailure:ansible.builtin.package"
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 1,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
-      "HasFailure",
-      "AnsibleTaskFailed:ansible.builtin.package"
+      "AnsibleFailure",
+      "AnsibleFailure:ansible.builtin.package"
     ],
-    "applied": 0,
-    "failed": 1,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 1,
+    "failure": 1
   }
 }

--- a/test/snapshots/ansible-package-install-nochange.json.snapshot.json
+++ b/test/snapshots/ansible-package-install-nochange.json.snapshot.json
@@ -67,24 +67,34 @@
           "friendly_message": "Package(s) neovim are present"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 1,
+          "failure": 0
+        },
+        "native": {
+          "changed": 0,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 1,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-package-install-success.json.snapshot.json
+++ b/test/snapshots/ansible-package-install-success.json.snapshot.json
@@ -79,24 +79,34 @@
           "friendly_message": "Package(s) neovim are present"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 1,
+          "nochange": 0,
+          "failure": 0
+        },
+        "native": {
+          "changed": 1,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
-        "HasChange"
+        "AnsibleChanged"
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 1,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
-      "HasChange"
+      "AnsibleChanged"
     ],
-    "applied": 1,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 1,
+    "nochange": 0,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-package-remove-failure.json.snapshot.json
+++ b/test/snapshots/ansible-package-remove-failure.json.snapshot.json
@@ -67,24 +67,34 @@
           "friendly_message": "Package(s) doesnotexist are absent"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 1,
+          "failure": 0
+        },
+        "native": {
+          "changed": 0,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 1,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-package-remove-success.json.snapshot.json
+++ b/test/snapshots/ansible-package-remove-success.json.snapshot.json
@@ -70,24 +70,34 @@
           "friendly_message": "Package(s) neovim are absent"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 1,
+          "nochange": 0,
+          "failure": 0
+        },
+        "native": {
+          "changed": 1,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
-        "HasChange"
+        "AnsibleChanged"
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 1,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
-      "HasChange"
+      "AnsibleChanged"
     ],
-    "applied": 1,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 1,
+    "nochange": 0,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-packates-install-many.json.snapshot.json
+++ b/test/snapshots/ansible-packates-install-many.json.snapshot.json
@@ -76,24 +76,34 @@
           "friendly_message": "Package(s) gcc, gcc-c++, make, cmake, vim-common, vim-minimal, vim, screen, tmux, bash and more are present"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 1,
+          "failure": 0
+        },
+        "native": {
+          "changed": 0,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 1,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-witty-nochange.json.snapshot.json
+++ b/test/snapshots/ansible-witty-nochange.json.snapshot.json
@@ -362,24 +362,34 @@
           "friendly_message": "N/A"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 7,
+          "failure": 0
+        },
+        "native": {
+          "changed": 0,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 7,
+    "failure": 0
   }
 }

--- a/test/snapshots/ansible-witty-success.json.snapshot.json
+++ b/test/snapshots/ansible-witty-success.json.snapshot.json
@@ -362,24 +362,34 @@
           "friendly_message": "N/A"
         }
       ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 7,
+          "failure": 0
+        },
+        "native": {
+          "changed": 0,
+          "failures": 0,
+          "ignored": 0,
+          "ok": 0,
+          "rescued": 0,
+          "skipped": 0,
+          "unreachable": 0
+        }
+      },
       "keywords": [
 
       ],
       "telemetry": {
-      },
-      "status": {
-        "applied": 0,
-        "failed": 0,
-        "skipped": 0
       },
       "check_mode": false
     },
     "keywords": [
 
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 7,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet-file-failure.yaml.snapshot.json
+++ b/test/snapshots/puppet-file-failure.yaml.snapshot.json
@@ -167,12 +167,24 @@
         "Schedule[never]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetResourceFailed:File[/tmp/xyz.txt]",
-        "PuppetHasFailure",
-        "PuppetIsOutOfSync",
-        "PuppetEnvironment:production"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 7,
+          "failure": 1
+        },
+        "native": {
+          "total": 8,
+          "skipped": 0,
+          "failed": 1,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 1,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "File[/tmp/xyz.txt]",
@@ -208,17 +220,24 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusFailed",
+        "PuppetFailed:File[/tmp/xyz.txt]",
+        "PuppetFailed",
+        "PuppetOutOfSync",
+        "PuppetEnvironment:production"
+      ]
     },
     "keywords": [
-      "PuppetResourceFailed:File[/tmp/xyz.txt]",
-      "PuppetHasFailure",
-      "PuppetIsOutOfSync",
+      "PuppetStatusFailed",
+      "PuppetFailed:File[/tmp/xyz.txt]",
+      "PuppetFailed",
+      "PuppetOutOfSync",
       "PuppetEnvironment:production"
     ],
-    "applied": 0,
-    "failed": 1,
-    "pending": 0,
-    "other": 1
+    "change": 0,
+    "nochange": 7,
+    "failure": 1
   }
 }

--- a/test/snapshots/puppet-file-nochange.yaml.snapshot.json
+++ b/test/snapshots/puppet-file-nochange.yaml.snapshot.json
@@ -157,9 +157,24 @@
         "Schedule[never]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 8,
+          "failure": 0
+        },
+        "native": {
+          "total": 8,
+          "skipped": 0,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 0,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "File[/tmp/xyz.txt]",
@@ -195,14 +210,18 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production"
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 8,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet-file-success.yaml.snapshot.json
+++ b/test/snapshots/puppet-file-success.yaml.snapshot.json
@@ -162,11 +162,24 @@
         "Schedule[never]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetHasChange",
-        "PuppetIsOutOfSync",
-        "PuppetEnvironment:production"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 1,
+          "nochange": 7,
+          "failure": 0
+        },
+        "native": {
+          "total": 8,
+          "skipped": 0,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 1,
+          "out_of_sync": 1,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "File[/tmp/xyz.txt]",
@@ -202,16 +215,20 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusChanged",
+        "PuppetOutOfSync",
+        "PuppetEnvironment:production"
+      ]
     },
     "keywords": [
-      "PuppetHasChange",
-      "PuppetIsOutOfSync",
+      "PuppetStatusChanged",
+      "PuppetOutOfSync",
       "PuppetEnvironment:production"
     ],
-    "applied": 1,
-    "failed": 0,
-    "pending": 0,
-    "other": 1
+    "change": 1,
+    "nochange": 7,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet-nothing-nochange.yaml.snapshot.json
+++ b/test/snapshots/puppet-nothing-nochange.yaml.snapshot.json
@@ -201,9 +201,24 @@
         "Schedule[never]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 7,
+          "failure": 0
+        },
+        "native": {
+          "total": 7,
+          "skipped": 0,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 0,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "Schedule[daily]",
@@ -235,14 +250,18 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production"
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 7,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet6-foreman-deb.yaml.snapshot.json
+++ b/test/snapshots/puppet6-foreman-deb.yaml.snapshot.json
@@ -699,11 +699,24 @@
         "Cron[puppet]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production",
-        "PuppetResourceFailed:Package[bzip2]",
-        "PuppetHasFailure"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 405,
+          "failure": 0
+        },
+        "native": {
+          "total": 405,
+          "skipped": 0,
+          "failed": 1,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 0,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "Exec[ruby-2.6.3/update_rubygems]",
@@ -827,16 +840,22 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production",
+        "PuppetFailed:Package[bzip2]",
+        "PuppetFailed"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production",
-      "PuppetResourceFailed:Package[bzip2]",
-      "PuppetHasFailure"
+      "PuppetFailed:Package[bzip2]",
+      "PuppetFailed"
     ],
-    "applied": 0,
-    "failed": 1,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 405,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet6-foreman-dis.yaml.snapshot.json
+++ b/test/snapshots/puppet6-foreman-dis.yaml.snapshot.json
@@ -402,9 +402,24 @@
         "Cron[puppet]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 168,
+          "failure": 0
+        },
+        "native": {
+          "total": 168,
+          "skipped": 0,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 0,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "File[/usr/bin/example-snapshot]",
@@ -528,14 +543,18 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production"
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 168,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet6-foreman-jen.yaml.snapshot.json
+++ b/test/snapshots/puppet6-foreman-jen.yaml.snapshot.json
@@ -640,9 +640,24 @@
         "Cron[puppet]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 346,
+          "failure": 0
+        },
+        "native": {
+          "total": 346,
+          "skipped": 0,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 0,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "Package[ansible]",
@@ -766,14 +781,18 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production"
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 346,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet6-foreman-old.yaml.snapshot.json
+++ b/test/snapshots/puppet6-foreman-old.yaml.snapshot.json
@@ -141,9 +141,24 @@
         "Schedule[never]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 7,
+          "failure": 0
+        },
+        "native": {
+          "total": 7,
+          "skipped": 0,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 0,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "Filebucket[puppet]",
@@ -175,14 +190,18 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production"
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 0
+    "change": 0,
+    "nochange": 7,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet6-foreman-red.yaml.snapshot.json
+++ b/test/snapshots/puppet6-foreman-red.yaml.snapshot.json
@@ -669,10 +669,24 @@
         "Postgresql_psql[grant:database:GRANT adminpz8bn8d - ALL - redmine4]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production",
-        "PuppetIsOutOfSync"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 400,
+          "failure": 0
+        },
+        "native": {
+          "total": 400,
+          "skipped": 0,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 0,
+          "out_of_sync": 2,
+          "scheduled": 0,
+          "corrective_change": 0
+        }
+      },
       "evaluation_times": [
         [
           "File[/usr/local/sbin/letsencrypt-domain-validation]",
@@ -796,15 +810,20 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production",
+        "PuppetOutOfSync"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production",
-      "PuppetIsOutOfSync"
+      "PuppetOutOfSync"
     ],
-    "applied": 0,
-    "failed": 0,
-    "pending": 0,
-    "other": 2
+    "change": 0,
+    "nochange": 400,
+    "failure": 0
   }
 }

--- a/test/snapshots/puppet6-foreman-web.yaml.snapshot.json
+++ b/test/snapshots/puppet6-foreman-web.yaml.snapshot.json
@@ -793,14 +793,24 @@
         "Concat_fragment[stagingdeb-https-file_footer]",
         "Filebucket[puppet]"
       ],
-      "keywords": [
-        "PuppetEnvironment:production",
-        "PuppetHasCorrectiveChange",
-        "PuppetHasSkips",
-        "PuppetResourceFailed:File[mime_magic.conf]",
-        "PuppetHasFailure",
-        "PuppetHasChange"
-      ],
+      "summary": {
+        "foreman": {
+          "change": 0,
+          "nochange": 539,
+          "failure": 0
+        },
+        "native": {
+          "total": 539,
+          "skipped": 1,
+          "failed": 0,
+          "failed_to_restart": 0,
+          "restarted": 0,
+          "changed": 1,
+          "out_of_sync": 0,
+          "scheduled": 0,
+          "corrective_change": 1
+        }
+      },
       "evaluation_times": [
         [
           "Selmodule[rsync_debug]",
@@ -924,19 +934,26 @@
         ]
       ],
       "telemetry": {
-      }
+      },
+      "keywords": [
+        "PuppetStatusUnchanged",
+        "PuppetEnvironment:production",
+        "PuppetCorrectiveChange",
+        "PuppetSkipped",
+        "PuppetFailedToRestart:File[mime_magic.conf]",
+        "PuppetFailedToRestart"
+      ]
     },
     "keywords": [
+      "PuppetStatusUnchanged",
       "PuppetEnvironment:production",
-      "PuppetHasCorrectiveChange",
-      "PuppetHasSkips",
-      "PuppetResourceFailed:File[mime_magic.conf]",
-      "PuppetHasFailure",
-      "PuppetHasChange"
+      "PuppetCorrectiveChange",
+      "PuppetSkipped",
+      "PuppetFailedToRestart:File[mime_magic.conf]",
+      "PuppetFailedToRestart"
     ],
-    "applied": 2,
-    "failed": 0,
-    "pending": 0,
-    "other": 1
+    "change": 0,
+    "nochange": 539,
+    "failure": 0
   }
 }


### PR DESCRIPTION
Implements the final mapping after discussion at:

https://community.theforeman.org/t/new-config-report-summary-columns/26531

See the original post for the change, nochange and failure mapping as well as keywords.

The patch also removes SSL setting which was recently droped in Foreman core and tests were not passing anymore.

Note this change: https://github.com/theforeman/foreman-ansible-modules/pull/1325/files

Ansible Foreman callback in 3.1+ will send a root element called "summary" containing all the Ansible statuses unchanged. Previously it was called "status" and the callback was trying to calculate something. Most of the fixtures do not contain the summary yet, but proxy will convert this to the new format.

@ofedoren @ron-lavi