### PR TITLE
Return HTTP status code 202 Accepted

### DIFF
--- a/lib/smart_proxy_reports/reports_api.rb
+++ b/lib/smart_proxy_reports/reports_api.rb
@@ -47,6 +47,7 @@ module Proxy::Reports
       log_halt(415, "Missing body") if input.empty?
       json_body = to_bool(params[:json_body], true)
       processor = Processor.new_processor(format, input, json_body: json_body)
+      status 202
       processor.spool_report
     rescue => e
       log_halt 415, e, "Error during report processing: #{e.message}"

--- a/test/ansible_processor_test.rb
+++ b/test/ansible_processor_test.rb
@@ -11,13 +11,13 @@ class AnsibleProcessorTest < Test::Unit::TestCase
     assert check_hash_keys(report), "All keys are strings: #{report.inspect}"
   end
 
-  Dir.glob(File.join(File.dirname(__FILE__), "fixtures", "ansible*json")).each do |fixture_filename|
+  Dir.glob(File.join(__dir__, "fixtures", "ansible*json")).each do |fixture_filename|
     fixture_filename = File.basename(fixture_filename.tr("- ", "--"))
     define_method("test_snapshot_#{fixture_filename}") do
       processor = setup_processor("ansible", fixture_filename)
       result = processor.build_report
       remove_volatile_keys(result)
-      snapshot_filename = File.join(File.dirname(__FILE__), "snapshots", "#{File.basename(fixture_filename)}.snapshot.json")
+      snapshot_filename = File.join(__dir__, "snapshots", "#{File.basename(fixture_filename)}.snapshot.json")
       assert_snapshot(result, snapshot_filename)
     end
   end

--- a/test/puppet_processor_test.rb
+++ b/test/puppet_processor_test.rb
@@ -11,13 +11,13 @@ class PuppetProcessorTest < Test::Unit::TestCase
     assert check_hash_keys(report), "All keys are strings: #{report.inspect}"
   end
 
-  Dir.glob(File.join(File.dirname(__FILE__), "fixtures", "puppet*yaml")).each do |fixture_filename|
+  Dir.glob(File.join(__dir__, "fixtures", "puppet*yaml")).each do |fixture_filename|
     fixture_filename = File.basename(fixture_filename.tr("- ", "--"))
     define_method("test_snapshot_#{fixture_filename}") do
       processor = setup_processor("puppet", fixture_filename)
       result = processor.build_report
       remove_volatile_keys(result)
-      snapshot_filename = File.join(File.dirname(__FILE__), "snapshots", "#{File.basename(fixture_filename)}.snapshot.json")
+      snapshot_filename = File.join(__dir__, "snapshots", "#{File.basename(fixture_filename)}.snapshot.json")
       assert_snapshot(result, snapshot_filename)
     end
   end

--- a/test/reports_integration_test.rb
+++ b/test/reports_integration_test.rb
@@ -34,7 +34,7 @@ class ReportsIntegrationTest < Test::Unit::TestCase
 
   def test_valid_puppet
     ::Proxy::Reports::SpooledHttpClient.instance.expects(:spool)
-    yaml = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-old.yaml"))
+    yaml = File.read(File.join(__dir__, "fixtures/puppet6-foreman-old.yaml"))
     post "/puppet", yaml, { "CONTENT_TYPE" => "application/x-yaml" }
     assert_equal "", last_response.body
     assert_equal 202, last_response.status

--- a/test/reports_integration_test.rb
+++ b/test/reports_integration_test.rb
@@ -37,6 +37,6 @@ class ReportsIntegrationTest < Test::Unit::TestCase
     yaml = File.read(File.join(File.dirname(__FILE__), "fixtures/puppet6-foreman-old.yaml"))
     post "/puppet", yaml, { "CONTENT_TYPE" => "application/x-yaml" }
     assert_equal "", last_response.body
-    assert_equal 200, last_response.status
+    assert_equal 202, last_response.status
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ def check_hash_keys(hoa)
 end
 
 def setup_processor(type, filename)
-  input = File.read(File.join(File.dirname(__FILE__), "fixtures/#{filename}"))
+  input = File.read(File.join(__dir__, "fixtures/#{filename}"))
   ::Proxy::Reports::Processor.new_processor(type, input, json_body: false)
 end
 


### PR DESCRIPTION
When a report is accepted but not processed the 202 Accepted code is more appropriate. Quoting [Wikipedia](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes):

> The request has been accepted for processing, but the processing has not been completed. The request might or might not be eventually acted upon, and may be disallowed when processing occurs.